### PR TITLE
Fix streamed citations not being rendered

### DIFF
--- a/components/databricks-message-citation.tsx
+++ b/components/databricks-message-citation.tsx
@@ -1,0 +1,124 @@
+import type { ChatMessage } from '@/lib/types';
+import type {
+  AnchorHTMLAttributes,
+  ComponentType,
+  PropsWithChildren,
+} from 'react';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+
+/**
+ * ReactMarkdown/Streamdown component that handles Databricks message citations.
+ *
+ * @example
+ * <Streamdown components={{ a: DatabricksMessageCitationStreamdownIntegration }} />
+ */
+export const DatabricksMessageCitationStreamdownIntegration: ComponentType<
+  AnchorHTMLAttributes<HTMLAnchorElement>
+> = (props) => {
+  console.log('DatabricksMessageCitationStreamdownIntegration', props);
+  if (isDatabricksMessageCitationLink(props.href)) {
+    return (
+      <DatabricksMessageCitationRenderer
+        {...props}
+        href={decodeDatabricksMessageCitationLink(props.href)}
+      />
+    );
+  }
+  return <a {...props} />;
+};
+
+type SourcePart = Extract<ChatMessage['parts'][number], { type: 'source-url' }>;
+
+// Adds a unique suffix to the link to indicate that it is a Databricks message citation.
+const encodeDatabricksMessageCitationLink = (part: SourcePart) =>
+  `${part.url}::databricks_citation`;
+
+// Removes the unique suffix from the link to get the original link.
+const decodeDatabricksMessageCitationLink = (link: string) =>
+  link.replace('::databricks_citation', '');
+
+// Creates a markdown link to the Databricks message citation.
+export const createDatabricksMessageCitationMarkdown = (part: SourcePart) =>
+  `[${part.title || part.url}](${encodeDatabricksMessageCitationLink(part)})`;
+
+// Checks if the link is a Databricks message citation.
+const isDatabricksMessageCitationLink = (
+  link?: string,
+): link is `${string}::databricks_citation` =>
+  link?.endsWith('::databricks_citation') ?? false;
+
+// Renders the Databricks message citation.
+const DatabricksMessageCitationRenderer = (
+  props: PropsWithChildren<{
+    href: string;
+  }>,
+) => {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <a
+          href={props.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-md bg-muted-foreground px-2 py-0"
+        >
+          {props.children}
+        </a>
+      </TooltipTrigger>
+      <TooltipContent
+        style={{ maxWidth: '300px', padding: '8px', wordWrap: 'break-word' }}
+      >
+        {props.href}
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+/**
+ * Creates segments of parts that can be rendered as a single component.
+ * Used to render citations as part of the associated text.
+ */
+export const createMessagePartSegments = (parts: ChatMessage['parts']) => {
+  // An array of arrays of parts
+  // Allows us to render multiple parts as a single component
+  const out: ChatMessage['parts'][] = [];
+  for (const part of parts) {
+    const lastBlock = out[out.length - 1] || null;
+    const previousPart = lastBlock?.[lastBlock.length - 1] || null;
+
+    // If the previous part is a text part and the current part is a source part, add it to the current block
+    if (previousPart?.type === 'text' && part.type === 'source-url') {
+      lastBlock.push(part);
+    }
+    // If the previous part is a source-url part and the current part is a source part, add it to the current block
+    else if (
+      previousPart?.type === 'source-url' &&
+      part.type === 'source-url'
+    ) {
+      lastBlock.push(part);
+    }
+    // Otherwise, add the current part to a new block
+    else {
+      out.push([part]);
+    }
+  }
+
+  return out;
+};
+
+/**
+ * Takes a segment of parts and joins them into a markdown-formatted string.
+ * Used to render citations as part of the associated text.
+ */
+export const joinMessagePartSegments = (parts: ChatMessage['parts']) => {
+  return parts.reduce((acc, part) => {
+    switch (part.type) {
+      case 'text':
+        return acc + part.text;
+      case 'source-url':
+        return `${acc} ${createDatabricksMessageCitationMarkdown(part)}`;
+      default:
+        return acc;
+    }
+  }, '');
+};

--- a/components/elements/response.tsx
+++ b/components/elements/response.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@/lib/utils';
 import { type ComponentProps, memo } from 'react';
 import { Streamdown } from 'streamdown';
+import { DatabricksMessageCitationStreamdownIntegration } from '../databricks-message-citation';
 
 type ResponseProps = ComponentProps<typeof Streamdown>;
 
@@ -13,6 +14,9 @@ export const Response = memo(
         'size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_code]:whitespace-pre-wrap [&_code]:break-words [&_pre]:max-w-full [&_pre]:overflow-x-auto',
         className,
       )}
+      components={{
+        a: DatabricksMessageCitationStreamdownIntegration,
+      }}
       {...props}
     />
   ),

--- a/lib/databricks-text-parts.ts
+++ b/lib/databricks-text-parts.ts
@@ -33,6 +33,9 @@ export const applyDatabricksTextPartTransform: DatabricksStreamPartTransformer<
       currentLast?.type !== 'text-delta'
     ) {
       // Filter this one out
+    } else {
+      // Otherwise, pass through the incoming chunk
+      out.push(incoming);
     }
 
     currentLast = out[out.length - 1] ?? currentLast;


### PR DESCRIPTION
Add support for inline citations with controllable rendering path.

<img width="866" height="606" alt="image" src="https://github.com/user-attachments/assets/ebca6831-36b1-4182-b500-c3163f89b63e" />

<img width="351" height="219" alt="image" src="https://github.com/user-attachments/assets/1ee57f3c-343f-4a4b-9f75-9f7e280585ed" />
