### PR TITLE
Add reasoning delta transformer

### DIFF
--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -16,6 +16,7 @@ import {
   DATABRICKS_TOOL_CALL_ID,
 } from '../databricks-tool-calling';
 import { applyDatabricksTextPartTransform } from '../databricks-text-parts';
+import { applyDatabricksReasoningStreamPartTransform } from '../databricks-reasoning-transformer';
 
 // OAuth token management
 let oauthToken: string | null = null;
@@ -318,6 +319,7 @@ const databricksMiddleware: LanguageModelV2Middleware = {
     const { stream, ...rest } = await doStream();
     let lastChunk = null as LanguageModelV2StreamPart | null;
     const transformerStreamParts = composeDatabricksStreamPartTransformers(
+      applyDatabricksReasoningStreamPartTransform,
       applyDatabricksTextPartTransform,
       applyDatabricksToolCallStreamPartTransform,
     );

--- a/lib/databricks-reasoning-transformer.ts
+++ b/lib/databricks-reasoning-transformer.ts
@@ -1,0 +1,76 @@
+import type { LanguageModelV2StreamPart } from '@ai-sdk/provider';
+import type { DatabricksStreamPartTransformer } from './databricks-stream-part-transformers';
+
+type DatabricksReasoningDeltaStreamPart = {
+  INCOMING_TYPE: {
+    type: 'raw';
+    rawValue: {
+      type: 'response.reasoning_text.delta';
+      item_id: string;
+      output_index: number;
+      content_index: number;
+      delta: string;
+      sequence_number: number;
+      id: string;
+    };
+  };
+  OUTGOING_TYPE: Extract<
+    LanguageModelV2StreamPart,
+    { type: `reasoning-${string}` }
+  >;
+};
+
+/**
+ * Stream part transformers
+ */
+export const applyDatabricksReasoningStreamPartTransform: DatabricksStreamPartTransformer<
+  LanguageModelV2StreamPart
+> = (parts, last) => {
+  let currentLast = last;
+  const out: LanguageModelV2StreamPart[] = [];
+  for (const part of parts) {
+    const injections: LanguageModelV2StreamPart[] = [];
+    if (isRawReasoningDelta(part)) {
+      injections.push(...transformReasoningDelta(part, last));
+    }
+    if (injections.length > 0) {
+      out.push(...injections);
+      currentLast = out[out.length - 1] ?? currentLast;
+    } else {
+      out.push(part);
+    }
+  }
+  return {
+    out,
+    last: currentLast,
+  };
+};
+
+const transformReasoningDelta = (
+  part: DatabricksReasoningDeltaStreamPart['INCOMING_TYPE'],
+  last: LanguageModelV2StreamPart | null,
+): DatabricksReasoningDeltaStreamPart['OUTGOING_TYPE'][] => {
+  const reasoningDelta: DatabricksReasoningDeltaStreamPart['OUTGOING_TYPE'] = {
+    type: 'reasoning-delta',
+    id: part.rawValue.id,
+    delta: part.rawValue.delta,
+  };
+
+  const shouldStartNewReasoningBlock =
+    !last ||
+    (last?.type !== 'reasoning-delta' && last?.type !== 'reasoning-start');
+
+  if (shouldStartNewReasoningBlock) {
+    return [{ type: 'reasoning-start', id: part.rawValue.id }, reasoningDelta];
+  }
+  return [reasoningDelta];
+};
+
+/**
+ * Type guards
+ */
+export const isRawReasoningDelta = (
+  part: LanguageModelV2StreamPart,
+): part is DatabricksReasoningDeltaStreamPart['INCOMING_TYPE'] =>
+  part.type === 'raw' &&
+  (part.rawValue as any)?.type === 'response.reasoning_text.delta';

--- a/lib/databricks-text-parts.ts
+++ b/lib/databricks-text-parts.ts
@@ -8,37 +8,39 @@ export const applyDatabricksTextPartTransform: DatabricksStreamPartTransformer<
   let currentLast: LanguageModelV2StreamPart | null = last;
 
   for (const incoming of parts) {
+    const injections: LanguageModelV2StreamPart[] = [];
     // 1️⃣ Close a dangling text-delta when a non‑text chunk arrives.
     if (
       currentLast?.type === 'text-delta' &&
       incoming.type !== 'text-delta' &&
       incoming.type !== 'text-end'
     ) {
-      out.push(incoming);
+      // Passthrough
     } else if (
       // 2️⃣ We have a fresh text‑delta chunk → inject a `text-start`.
       incoming.type === 'text-delta' &&
       (currentLast === null || currentLast.type !== 'text-delta')
     ) {
-      out.push({ type: 'text-start', id: incoming.id }, incoming);
+      injections.push({ type: 'text-start', id: incoming.id }, incoming);
     } else if (
       // 3️⃣ A `text-delta` with a **different** id follows another `text-delta` → close the
       incoming.type === 'text-delta' &&
       currentLast?.type === 'text-delta' &&
       currentLast.id !== incoming.id
     ) {
-      out.push({ type: 'text-start', id: incoming.id }, incoming);
+      injections.push({ type: 'text-start', id: incoming.id }, incoming);
     } else if (
       incoming.type === 'text-end' &&
       currentLast?.type !== 'text-delta'
     ) {
       // Filter this one out
+    }
+    if (injections.length > 0) {
+      out.push(...injections);
+      currentLast = out[out.length - 1] ?? currentLast;
     } else {
-      // Otherwise, pass through the incoming chunk
       out.push(incoming);
     }
-
-    currentLast = out[out.length - 1] ?? currentLast;
   }
 
   return { out, last: currentLast };


### PR DESCRIPTION
Transforms `response.reasoning_text.delta` response items to `reasoning-delta` events and injects `reasoning-start` events if they are absent.

In reality, `@ai-sdk` expects `response.reasoning_summary_text.delta` events but KA does not output this. 

<img width="631" height="1023" alt="image" src="https://github.com/user-attachments/assets/6105becf-b3b9-4cfb-9304-78f840da9243" />
