### PR TITLE
Avoid rendering duplicate text parts

### DIFF
--- a/databricks/stream-transformers/databricks-text-parts.ts
+++ b/databricks/stream-transformers/databricks-text-parts.ts
@@ -8,6 +8,9 @@ export const applyDatabricksTextPartTransform: DatabricksStreamPartTransformer<
 
   for (const incoming of parts) {
     if (isRawAssistantMessagePart(incoming)) {
+      if (last?.type === 'text-delta') {
+        out.push({ type: 'text-end', id: last.id });
+      }
       out.push(
         { type: 'text-start', id: incoming.rawValue.item.id },
         rawAssistantMessagePartToTextPart(incoming),


### PR DESCRIPTION
Avoid rendering duplicate text parts by correctly inserting a text-end block when receiving a raw assistant message following a delta