### PR TITLE
Surface errors from model endpoint

### DIFF
--- a/components/elements/actions.tsx
+++ b/components/elements/actions.tsx
@@ -21,6 +21,7 @@ export const Actions = ({ className, children, ...props }: ActionsProps) => (
 type ActionProps = ComponentProps<typeof Button> & {
   tooltip?: string;
   label?: string;
+  iconOnly?: boolean;
 };
 
 export const Action = ({
@@ -30,12 +31,14 @@ export const Action = ({
   className,
   variant = 'ghost',
   size = 'sm',
+  iconOnly = true,
   ...props
 }: ActionProps) => {
   const button = (
     <Button
       className={cn(
-        'relative size-9 p-1.5 text-muted-foreground hover:text-foreground',
+        'relative text-muted-foreground hover:text-foreground',
+        iconOnly ? 'size-9 p-1.5' : 'h-9 px-2.5',
         className,
       )}
       size={size}

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -5,7 +5,7 @@ import { Actions, Action } from './elements/actions';
 import { memo } from 'react';
 import { toast } from 'sonner';
 import type { ChatMessage } from '@/lib/types';
-import { cn } from '@/lib/utils';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 
 function PureMessageActions({
   message,
@@ -78,23 +78,7 @@ function PureMessageActions({
           iconOnly={false}
         >
           <div className="flex items-center gap-1.5">
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 16 16"
-              fill="none"
-              className={cn('transition-transform', {
-                'rotate-180': showErrors,
-              })}
-            >
-              <path
-                d="M4 6L8 10L12 6"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            {showErrors ? <ChevronUp /> : <ChevronDown />}
             <span className="text-xs">
               {errorCount} {errorCount === 1 ? 'error' : 'errors'}
             </span>

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -5,15 +5,22 @@ import { Actions, Action } from './elements/actions';
 import { memo } from 'react';
 import { toast } from 'sonner';
 import type { ChatMessage } from '@/lib/types';
+import { cn } from '@/lib/utils';
 
 function PureMessageActions({
   message,
   isLoading,
   setMode,
+  errorCount = 0,
+  showErrors = false,
+  onToggleErrors,
 }: {
   message: ChatMessage;
   isLoading: boolean;
   setMode?: (mode: 'view' | 'edit') => void;
+  errorCount?: number;
+  showErrors?: boolean;
+  onToggleErrors?: () => void;
 }) {
   const [_, copyToClipboard] = useCopyToClipboard();
 
@@ -59,9 +66,41 @@ function PureMessageActions({
 
   return (
     <Actions className="-ml-0.5">
-      <Action tooltip="Copy" onClick={handleCopy}>
-        <CopyIcon />
-      </Action>
+      {textFromParts && (
+        <Action tooltip="Copy" onClick={handleCopy}>
+          <CopyIcon />
+        </Action>
+      )}
+      {errorCount > 0 && onToggleErrors && (
+        <Action
+          tooltip={showErrors ? 'Hide errors' : 'Show errors'}
+          onClick={onToggleErrors}
+          iconOnly={false}
+        >
+          <div className="flex items-center gap-1.5">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              className={cn('transition-transform', {
+                'rotate-180': showErrors,
+              })}
+            >
+              <path
+                d="M4 6L8 10L12 6"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <span className="text-xs">
+              {errorCount} {errorCount === 1 ? 'error' : 'errors'}
+            </span>
+          </div>
+        </Action>
+      )}
     </Actions>
   );
 }
@@ -70,6 +109,8 @@ export const MessageActions = memo(
   PureMessageActions,
   (prevProps, nextProps) => {
     if (prevProps.isLoading !== nextProps.isLoading) return false;
+    if (prevProps.errorCount !== nextProps.errorCount) return false;
+    if (prevProps.showErrors !== nextProps.showErrors) return false;
 
     return true;
   },

--- a/components/message-error.tsx
+++ b/components/message-error.tsx
@@ -1,0 +1,45 @@
+'use client';
+import { motion } from 'framer-motion';
+import { WarningIcon } from './icons';
+
+export const MessageError = ({ error }: { error: string }) => {
+  // Attempt to parse and format JSON error messages
+  const formatError = (
+    errorMessage: string,
+  ): { formatted: string; isJson: boolean } => {
+    try {
+      const parsed = JSON.parse(errorMessage);
+      return {
+        formatted: JSON.stringify(parsed, null, 2),
+        isJson: true,
+      };
+    } catch {
+      return {
+        formatted: errorMessage,
+        isJson: false,
+      };
+    }
+  };
+
+  const { formatted } = formatError(error);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="relative w-full"
+    >
+      <div className="flex w-fit items-center gap-1.5 rounded-t-md border border-destructive/20 border-b-0 bg-destructive/5 px-2.5 py-1.5">
+        <div className="text-destructive">
+          <WarningIcon size={14} />
+        </div>
+        <span className="font-medium text-destructive text-xs">Error</span>
+      </div>
+      <div className="rounded-b-lg rounded-tr-lg border border-destructive/20">
+        <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-muted p-2.5 font-mono text-foreground text-xs">
+          {formatted}
+        </pre>
+      </div>
+    </motion.div>
+  );
+};

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -27,6 +27,7 @@ import {
   joinMessagePartSegments,
 } from './databricks-message-part-transformers';
 import { components } from './elements/streamdown-components/components';
+import { MessageError } from './message-error';
 
 const PurePreviewMessage = ({
   chatId,
@@ -81,17 +82,11 @@ const PurePreviewMessage = ({
         )}
 
         <div
-          className={cn('flex min-w-0 flex-col', {
+          className={cn('flex w-full min-w-0 flex-col', {
             'gap-2 md:gap-4': message.parts?.some(
               (p) => p.type === 'text' && p.text?.trim(),
             ),
             'min-h-96': message.role === 'assistant' && requiresScrollPadding,
-            'w-full':
-              (message.role === 'assistant' &&
-                message.parts?.some(
-                  (p) => p.type === 'text' && p.text?.trim(),
-                )) ||
-              mode === 'edit',
             'max-w-[calc(100%-2.5rem)] sm:max-w-[min(fit-content,80%)]':
               message.role === 'user' && mode !== 'edit',
           })}
@@ -181,6 +176,11 @@ const PurePreviewMessage = ({
                   </div>
                 );
               }
+            }
+
+            // Support for error parts
+            if (part.type === 'data-error') {
+              return <MessageError key={key} error={part.data} />;
             }
 
             // Generic tool call support for OpenAI-style tools

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,15 +19,7 @@ export type ChatTools = {
 };
 
 export type CustomUIDataTypes = {
-  textDelta: string;
-  imageDelta: string;
-  sheetDelta: string;
-  codeDelta: string;
-  appendMessage: string;
-  id: string;
-  title: string;
-  clear: null;
-  finish: null;
+  error: string;
   usage: LanguageModelUsage;
 };
 


### PR DESCRIPTION
When just an error happened
<img width="752" height="574" alt="image" src="https://github.com/user-attachments/assets/031582fa-89c8-4812-9e34-61d95d72f6e2" />

When an error happened alongside generation (i.e. errored mid stream)
<img width="746" height="213" alt="image" src="https://github.com/user-attachments/assets/5a96fb2b-3a5a-4bdc-bb4d-5b4953faa30c" />
<img width="757" height="335" alt="image" src="https://github.com/user-attachments/assets/5582dd12-b825-4970-8ccd-da2d74797cd4" />

